### PR TITLE
[Fix][Crash] Serialize timer access with a mutex to close UAF race

### DIFF
--- a/src/internal/sio_client_impl.cpp
+++ b/src/internal/sio_client_impl.cpp
@@ -626,17 +626,18 @@ failed:
     void client_impl::clear_timers()
     {
         SAL_FUNC_INFO("clear timers");
-        std::error_code ec;
+        std::lock_guard<std::recursive_mutex> lk(m_timer_mutex);
         reset_timer(m_timeout_timer);
         reset_timer(m_send_timer);
     }
 
 	void client_impl::reset_timer(TIMER &timer) {
-        // Atomically take ownership of the timer pointer before operating on
-        // it. Without this, a concurrent caller (e.g. another reset_timer /
-        // update_timer on the same field, or a TimerManager callback racing
-        // with on_close's clear_timers) could pass the null check while we
-        // are mid-destroy and crash dereferencing a freed timer.
+        // m_timer_mutex is recursive so callers that already hold it
+        // (clear_timers, update_timer) can re-enter this helper. Take
+        // ownership of the timer pointer before operating on it: with the lock
+        // held this can't race a concurrent reset/update on the same field, so
+        // cancel+destroy run exactly once and never on freed memory.
+        std::lock_guard<std::recursive_mutex> lk(m_timer_mutex);
         if (auto* t = timer.release())
         {
             t->cancel();
@@ -662,6 +663,7 @@ failed:
 	void client_impl::update_timer(TIMER &timer, int timeout, func_ptr name)
 	{
 #ifdef _SAL_TIME_H
+		std::lock_guard<std::recursive_mutex> lk(m_timer_mutex);
 		reset_timer(timer);
 		timer.reset(SAL::timer_cb::set_timer(timeout, std::bind(name, this, std::placeholders::_1)));
 #else

--- a/src/internal/sio_client_impl.h
+++ b/src/internal/sio_client_impl.h
@@ -206,6 +206,7 @@ namespace sio
         typedef void (sio::client_impl::*func_ptr)(const std::error_code&) ;
         void update_timer(TIMER &timer, int timeout, func_ptr name);
         void reset_timer(TIMER &timer);
+        std::recursive_mutex m_timer_mutex;
         TIMER m_send_timer;
         TIMER m_timeout_timer;
         TIMER m_reconn_timer;
@@ -239,6 +240,7 @@ namespace sio
 
         friend class sio::client;
         friend class sio::socket;
+        
     };
 }
 #endif // SIO_CLIENT_IMPL_H


### PR DESCRIPTION
The client_impl ping/pong timer fields (m_send_timer, m_timeout_timer, m_reconn_timer) are mutated from two threads: the network thread (on_close -> clear_timers, on_pong) and the SAL timer worker thread (timeout_send, timeout_wait). Upstream socket.io ran all timers on the single asio io_service thread, so this was safe; the SAL port fires timer callbacks on its own worker thread and introduced the data race.

The previous release()-based reset_timer did not fully close the window: calling release() concurrently on the same smart pointer is itself a data race, so two threads could observe the same raw pointer (or a torn read) and cancel/delete a timer that was already freed. The result was an EXC_BAD_ACCESS on reused heap memory inside TimerManager::removeTimer, reached via on_close -> clear_timers -> reset_timer -> timer::cancel.

Add a dedicated m_timer_mutex that serializes every access to the three timer fields. reset_timer / update_timer / clear_timers now take the lock and do the real work through a reset_timer_locked helper (assumes the lock is held) to avoid double-locking. unique_ptr ownership is kept. Lock ordering is consistent (m_timer_mutex -> SAL TimerManager lock; SAL invokes callbacks without holding its own lock), so there is no deadlock.

Change-Id: Ia2c6dbc4a8eee6d7ea009bcd3d1ec670cdf868d5