### PR TITLE
[Fix][Crash] Serialize connection teardown with socket-queue I/O

### DIFF
--- a/src/internal/sio_client_impl.cpp
+++ b/src/internal/sio_client_impl.cpp
@@ -25,6 +25,8 @@
 #define SAL_FUNC_ERROR cout<<
 #else
 #include "SAL/Log/Log.h"
+#include "SAL/OS/SocketQueue.h"
+#include "SAL/OS/Sync.h"
 
 namespace {
     LOGGER_NAME("socketio.client")
@@ -143,6 +145,7 @@ namespace sio
         }
 
         auto it = m_sockets.find(aux);
+		SAL_FUNC_INFO("%d", it!= m_sockets.end());
         if(it!= m_sockets.end())
         {
             return it->second;
@@ -159,8 +162,19 @@ namespace sio
         m_con_state = con_closing;
         m_abort_retries = true;
         this->sockets_invoke_void(&sio::socket::close);
-        // m_client.get_io_service().dispatch(std::bind(&client_impl::close_impl, this,close::status::normal,"End by user"));
+#ifdef _SAL_TIME_H
+        // The websocket transport drives I/O on the socket-queue thread, so the
+        // close must run there too — otherwise it races with inbound frame
+        // handling. Post() runs inline when already on that thread (the common
+        // case here: close() is invoked from on_fail/on_open).
+        SAL_FUNC_INFO("close(): posting close_impl to socket-queue thread");
+        SAL::MSocketQueueManager::Post([this]() {
+            SAL_FUNC_INFO("close(): close_impl running on socket-queue thread");
+            this->close_impl(close::status::normal, "End by user");
+        });
+#else
         close_impl(close::status::normal,"End by user");
+#endif
     }
 
     void client_impl::sync_close()
@@ -168,8 +182,42 @@ namespace sio
         m_con_state = con_closing;
         m_abort_retries = true;
         this->sockets_invoke_void(&sio::socket::close);
-        // m_client.get_io_service().dispatch(std::bind(&client_impl::close_impl, this,close::status::normal,"End by user"));
+#ifdef _SAL_TIME_H
+        // Called from ~client_impl: the endpoint is about to be destroyed.
+        // Run close_impl on the socket-queue thread (serialized with inbound
+        // frame handling) and block until it has run, so no SocketQueueKpoll
+        // callback can touch this connection after we return. Run inline if we
+        // are already on that thread, to avoid self-deadlock.
+        if (SAL::MSocketQueueManager::IsOnQueueThread())
+        {
+            SAL_FUNC_INFO("sync_close: force-terminating inline (already on socket-queue thread)");
+            force_close_impl();
+            SAL_FUNC_INFO("sync_close: close completed (inline)");
+        }
+        else
+        {
+            SAL_FUNC_INFO("sync_close: dispatching force-close to socket-queue thread and waiting");
+            SAL::Event done(false);
+            SAL::MSocketQueueManager::Post([this, &done]() {
+                SAL_FUNC_INFO("sync_close: force_close_impl running on socket-queue thread");
+                this->force_close_impl();
+                done.signal();
+            });
+            // Bounded wait. A live loop runs the task within its 1s heartbeat;
+            // the timeout only guards against a wedged/dead loop so teardown
+            // can't block forever.
+            if (!done.wait(5000))
+            {
+                SAL_FUNC_ERROR("sync_close: timed out waiting for socket-queue close");
+            }
+            else
+            {
+                SAL_FUNC_INFO("sync_close: close completed on socket-queue thread");
+            }
+        }
+#else
         close_impl(close::status::normal,"End by user");
+#endif
         if(m_network_thread)
         {
             m_network_thread->join();
@@ -293,7 +341,7 @@ namespace sio
         reset_timer(m_reconn_timer);
         if (m_con.expired())
         {
-            cerr << "Error: No active session" << endl;
+            SAL_FUNC_ERROR("Error: No active session");
         }
         else
         {
@@ -301,9 +349,47 @@ namespace sio
             m_client.close(m_con, code, reason, ec);
             if(ec)
             {
-                cerr<<"close failed,reason:"<< ec.message()<<endl;
+                SAL_FUNC_WARN("close failed,reason: %d / %s", (int)ec.value(), ec.message().c_str()); // linux.socket: write(): send(143) failed with error 32
+                this->on_close(m_con); // force to closed even fail to avoid timeout_connection if reuse as con_opened
             }
         }
+    }
+
+    void client_impl::force_close_impl()
+    {
+        // Must run on the socket-queue thread (see sync_close). A graceful
+        // close (close_impl → m_client.close) only sends the close
+        // frame and waits for the peer's reply before the transport is shut
+        // down — that shutdown (which UNREGISTERS the socket from the socket
+        // queue) would otherwise happen AFTER ~client_impl, leaving the
+        // websocketpp connection alive in the loop with handlers bound to a
+        // freed client_impl → use-after-free in on_close.
+        //
+        // connection::terminate() forces it now: async_shutdown unregisters the
+        // socket synchronously, then handle_terminate fires on_close — all
+        // while client_impl is still alive. terminate() is idempotent.
+        reset_timer(m_reconn_timer);
+
+        // Prefer the strong ref (survives on_close's m_con.reset()). Fall back
+        // to the weak hdl if it is still valid.
+        client_type::connection_ptr con = m_con_strong;
+        if (!con && !m_con.expired())
+        {
+            lib::error_code ec;
+            con = m_client.get_con_from_hdl(m_con, ec);
+            if (ec) con.reset();
+        }
+
+        if (con)
+        {
+            SAL_FUNC_INFO("force_close_impl: terminating connection");
+            con->terminate(lib::error_code());
+        }
+        else
+        {
+            SAL_FUNC_INFO("force_close_impl: no active connection");
+        }
+        m_con_strong.reset();
     }
 
     void client_impl::send_impl(shared_ptr<const string> const& payload_ptr,frame::opcode::value opcode)
@@ -368,6 +454,7 @@ namespace sio
         {
             m_con_state = con_opening;
             m_reconn_made++;
+			this->sockets_invoke_void(&sio::socket::on_close);
             this->reset_states();
             SAL_FUNC_INFO("Reconnecting...");
             if(m_reconnecting_listener) m_reconnecting_listener();
@@ -444,6 +531,12 @@ namespace sio
         SAL_FUNC_INFO("Connected.");
         m_con_state = con_opened;
         m_con = con;
+        {
+            // Keep a strong ref so teardown can always reach the connection
+            // even after on_close resets the weak m_con.
+            lib::error_code __ec;
+            m_con_strong = m_client.get_con_from_hdl(con, __ec);
+        }
         m_reconn_made = 0;
         this->sockets_invoke_void(&sio::socket::on_open);
         this->socket("");

--- a/src/internal/sio_client_impl.h
+++ b/src/internal/sio_client_impl.h
@@ -134,6 +134,13 @@ namespace sio
 
         void close_impl(close::status::value const& code,std::string const& reason);
 
+        // Forceful, synchronous teardown of the active connection used at
+        // destruction time. Unlike close_impl (a graceful close that defers
+        // transport shutdown until the close handshake completes), this calls
+        // connection::terminate() so the socket is unregistered from the socket
+        // queue and on_close fires immediately — before the endpoint is freed.
+        void force_close_impl();
+
         void send_impl(std::shared_ptr<const std::string> const&  payload_ptr,frame::opcode::value opcode);
 
         void timeout_send(const std::error_code& ec);
@@ -187,6 +194,14 @@ namespace sio
         // Connection pointer for client functions.
         connection_hdl m_con;
         client_type m_client;
+        // Strong reference to the active connection, captured at on_open.
+        // m_con (a weak connection_hdl) is reset by on_close, which
+        // runs during teardown BEFORE the forceful close — leaving us unable to
+        // reach the still-registered connection. This strong ref survives that
+        // reset so force_close_impl can always terminate/unregister it.
+        // Declared after m_client so it is destroyed first (connection before
+        // endpoint).
+        client_type::connection_ptr m_con_strong;
         // Socket.IO server settings
         std::string m_sid;
         std::string m_base_url;


### PR DESCRIPTION
Under the SAL transport (_SAL_TIME_H) websocket I/O runs on the socket-queue event-loop thread, not on a network thread (m_network_thread is never created). close()/sync_close() ran close_impl on the caller's thread, racing the event-loop thread that was processing inbound frames on the same connection — a use-after- free / corrupted-mutex crash when the client is destroyed after a long background.

- close()/sync_close() now run the close on the socket-queue thread via MSocketQueueManager::Post (inline if already on it); sync_close blocks until it has run so the endpoint is safe to destroy.
- Add force_close_impl(): at destruction call connection::terminate() to unregister the socket and fire on_close synchronously, instead of a graceful close whose transport shutdown is deferred until after the client is freed (which left the connection alive in the loop with handlers bound to freed memory).
- Keep a strong connection ref (m_con_strong) captured at on_open; the weak m_con is reset by on_close during teardown, so the strong ref is what lets force_close_impl still reach and terminate the connection.

Change-Id: Iff28e31520b5a0642d5f3ba3cf3e6cd3edeefa76